### PR TITLE
Add install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a minimal FastAPI application skeleton for a document g
 
 ## Setup
 
-1. Create a virtual environment and install dependencies:
+1. Create a virtual environment and install dependencies manually:
 
    ```bash
    python -m venv venv
@@ -12,10 +12,17 @@ This repository contains a minimal FastAPI application skeleton for a document g
    pip install -r requirements.txt
    ```
 
-2. Run the application:
+2. Run the application manually:
 
    ```bash
    uvicorn app.main:app --reload
+   ```
+
+3. Alternatively, execute the included `install.sh` script to automatically
+   install dependencies, initialize the database and start the server:
+
+   ```bash
+   ./install.sh
    ```
 
 The API will be available at `http://localhost:8000/`.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Automated installation and launch script for it-site-yurist
+set -e
+
+if ! command -v python3 >/dev/null; then
+  echo "Python 3 is required but not installed." >&2
+  exit 1
+fi
+
+# Create virtual environment if not already present
+if [ ! -d "venv" ]; then
+  python3 -m venv venv
+fi
+
+# Activate environment and install dependencies
+source venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# Initialize the database
+python - <<'PY'
+from app.models import Base
+from app.core.db import engine
+Base.metadata.create_all(bind=engine)
+PY
+
+# Start the application
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- add `install.sh` for automatic installation and launch
- document usage of the script in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0ce595cc8329bbf2a60c493393f0