### PR TITLE
Fix install for hosting compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a minimal FastAPI application skeleton for a document g
 1. Create a virtual environment and install dependencies manually:
 
    ```bash
-   python -m venv venv
+   python3 -m venv venv
    source venv/bin/activate
    pip install -r requirements.txt
    ```
@@ -19,10 +19,12 @@ This repository contains a minimal FastAPI application skeleton for a document g
    ```
 
 3. Alternatively, execute the included `install.sh` script to automatically
-   install dependencies, initialize the database and start the server:
+   install dependencies, initialize the database and start the server. On
+   shared hosting environments like REG.RU, you may need to run the script
+   explicitly with `bash`:
 
    ```bash
-   ./install.sh
+   bash install.sh
    ```
 
 The API will be available at `http://localhost:8000/`.

--- a/install.sh
+++ b/install.sh
@@ -1,24 +1,29 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Automated installation and launch script for it-site-yurist
 set -e
 
-if ! command -v python3 >/dev/null; then
+# Detect available Python 3 interpreter
+if command -v python3 >/dev/null; then
+  PYTHON=python3
+elif command -v python >/dev/null; then
+  PYTHON=python
+else
   echo "Python 3 is required but not installed." >&2
   exit 1
 fi
 
 # Create virtual environment if not already present
 if [ ! -d "venv" ]; then
-  python3 -m venv venv
+  "$PYTHON" -m venv venv
 fi
 
 # Activate environment and install dependencies
 source venv/bin/activate
-pip install --upgrade pip
-pip install -r requirements.txt
+"$PYTHON" -m pip install --upgrade pip
+"$PYTHON" -m pip install -r requirements.txt
 
 # Initialize the database
-python - <<'PY'
+"$PYTHON" - <<'PY'
 from app.models import Base
 from app.core.db import engine
 Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
## Summary
- support `python` command in `install.sh`
- document using `python3` in setup steps
- note that `bash install.sh` might be needed on REG.RU hosting

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687db1b37bcc83298006543e44c4298c