### PR TITLE
Add static HTML site for easy hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # it-site-yurist
 
 This repository contains a minimal FastAPI application skeleton for a document generation service.
+The `static_site` directory contains an HTML version that works without installing any packages. Simply upload its contents to your hosting provider.
+
 
 ## Setup
 

--- a/static_site/index.html
+++ b/static_site/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Документооборот Юрист</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        header { text-align: center; }
+        nav ul { list-style: none; padding: 0; display: flex; justify-content: center; gap: 1rem; }
+        nav li { display: inline; }
+        main { margin-top: 2rem; }
+        footer { text-align: center; margin-top: 3rem; font-size: 0.9em; color: #666; }
+    </style>
+</head>
+<body>
+<header>
+    <h1>Юридический документооборот</h1>
+    <nav>
+        <ul>
+            <li><a href="#features">Возможности</a></li>
+            <li><a href="#usage">Развертывание</a></li>
+        </ul>
+    </nav>
+</header>
+<main>
+    <section id="features">
+        <h2>Возможности</h2>
+        <p>Система позволяет управлять шаблонами документов и генерировать их в виде HTML‑страниц. Для упрощения развёртывания весь сайт выполнен статически и не требует установки зависимостей.</p>
+    </section>
+    <section id="usage">
+        <h2>Развертывание</h2>
+        <p>Содержимое каталога <code>static_site</code> можно разместить на любом хостинге. Достаточно скопировать файлы через FTP или файловый менеджер панели управления.</p>
+    </section>
+</main>
+<footer>
+    &copy; 2024 it-site-yurist
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a small static_site folder with index.html
- mention the static site option in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e750dd0788329abdd6b0d167453a3